### PR TITLE
feat: Add Colab-compatible Gemma-2B fine-tuning notebook

### DIFF
--- a/gemma-2b-finetune-colab.ipynb
+++ b/gemma-2b-finetune-colab.ipynb
@@ -1,0 +1,444 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fine-tuning Gemma-2B for Google Colab\\n",
+    "\n",
+    "This notebook provides a complete workflow for fine-tuning the `google/gemma-2b` model on Google Colab, using a standard GPU runtime (like a T4). It leverages NVIDIA's CUDA for GPU acceleration and uses memory-efficient techniques like 4-bit quantization and QLoRA to make the process feasible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Setup and Environment\n",
+    "\n",
+    "First, we install the necessary libraries. We use `bitsandbytes` for quantization, `peft` for LoRA, `trl` for the SFTTrainer, and `transformers` for the model and tokenizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118\\n",
+    "!pip install -q -U accelerate bitsandbytes peft transformers trl datasets huggingface_hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Log in to the Hugging Face Hub to download the model and push your fine-tuned adapter. You will need to generate a token with 'write' permissions from your Hugging Face account settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import login\n",
+    "\n",
+    "login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Load and Prepare Data\n",
+    "\n",
+    "We will load two datasets from the Hugging Face Hub:\n",
+    "1. `michsethowusu/english-tooro_sentence-pairs_mt560`: A translation dataset.\n",
+    "2. `cle-13/rutooro_multitask`: A multi-task instruction dataset.\n",
+    "\n",
+    "We'll then merge them and format them into a consistent instruction-response format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset, concatenate_datasets\n",
+    "\n",
+    "# Load the datasets\n",
+    "translation_dataset = load_dataset(\"michsethowusu/english-tooro_sentence-pairs_mt560\", split='train')\n",
+    "multitask_dataset = load_dataset(\"cle-13/rutooro_multitask\", split='train')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Formatting\n",
+    "\n",
+    "To fine-tune the model, we need to format the examples into a single text field. The format should clearly separate the instruction from the response. We will use the following structure:\n",
+    "\n",
+    "```\n",
+    "### Instruction:\\n[Instruction Text]\\n\\n### Response:\\n[Response Text]\n",
+    "```\n",
+    "We create a function that handles the two different structures of our source datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def format_instruction(sample):\n",
+    "    # Handle the multitask dataset which has 'instruction', 'input', 'output' columns\n",
+    "    if 'instruction' in sample:\n",
+    "        instruction = sample['instruction']\n",
+    "        input_text = sample.get('input', '')\n",
+    "        response = sample['output']\n",
+    "        if input_text:\n",
+    "            return f\"### Instruction:\\n{instruction}\\n{input_text}\\n\\n### Response:\\n{response}\"\n",
+    "        else:\n",
+    "            return f\"### Instruction:\\n{instruction}\\n\\n### Response:\\n{response}\"\n",
+    "    # Handle the translation dataset which has 'en' and 'tt' columns\n",
+    "    elif 'en' in sample and 'tt' in sample:\n",
+    "        instruction = f\"Translate this to Rutooro: {sample['en']}\"\n",
+    "        response = sample['tt']\n",
+    "        return f\"### Instruction:\\n{instruction}\\n\\n### Response:\\n{response}\"\n",
+    "    else:\n",
+    "        # Handle cases where columns might be missing or have different names\n",
+    "        raise ValueError(f\"Unexpected sample structure: {sample.keys()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we apply this formatting function to both datasets and merge them. We also split the final dataset into a 90% training set and a 10% testing set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Process and format each dataset\n",
+    "formatted_translation_dataset = translation_dataset.map(lambda x: {'text': format_instruction(x)})\n",
+    "formatted_multitask_dataset = multitask_dataset.map(lambda x: {'text': format_instruction(x)})\n",
+    "\n",
+    "# Select only the 'text' column\n",
+    "formatted_translation_dataset = formatted_translation_dataset.select_columns(['text'])\n",
+    "formatted_multitask_dataset = formatted_multitask_dataset.select_columns(['text'])\n",
+    "\n",
+    "# Merge the datasets\n",
+    "merged_dataset = concatenate_datasets([formatted_translation_dataset, formatted_multitask_dataset])\n",
+    "\n",
+    "# Shuffle the dataset for better training distribution\n",
+    "merged_dataset = merged_dataset.shuffle(seed=42)\n",
+    "\n",
+    "# Split into training and testing sets\n",
+    "dataset_splits = merged_dataset.train_test_split(test_size=0.1)\n",
+    "train_dataset = dataset_splits['train']\n",
+    "test_dataset = dataset_splits['test']\n",
+    "\n",
+    "print(f\"Training set size: {len(train_dataset)}\")\n",
+    "print(f\"Testing set size: {len(test_dataset)}\")\n",
+    "print(\"\\nExample entry:\\n\", train_dataset[0]['text'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Load the Model and Tokenizer\n",
+    "\n",
+    "Now we load the `google/gemma-2b` model. We'll use 4-bit quantization via `bitsandbytes` to reduce the memory footprint. This is essential for running large models in a Colab environment.\n",
+    "\n",
+    "We explicitly check for CUDA availability to ensure we're using the GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig\n",
+    "\n",
+    "# Check for CUDA availability\n",
+    "if torch.cuda.is_available():\n",
+    "    print(\"CUDA is available. Using CUDA.\")\n",
+    "    device = \"cuda\"\n",
+    "else:\n",
+    "    print(\"CUDA not available. Running on CPU may be slow.\")\n",
+    "    device = \"cpu\"\n",
+    "\n",
+    "model_id = \"google/gemma-2b\"\n",
+    "\n",
+    "# Configure quantization for CUDA\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True,\n",
+    "    bnb_4bit_quant_type=\"nf4\",\n",
+    "    bnb_4bit_compute_dtype=torch.float16\n",
+    ")\n",
+    "\n",
+    "# Load the model\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_id,\n",
+    "    quantization_config=bnb_config,\n",
+    "    device_map=\"auto\" # Automatically map model layers to available devices\n",
+    ")\n",
+    "\n",
+    "# Load the tokenizer\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_id)\n",
+    "tokenizer.padding_side = 'right' # Set padding side for proper batching\n",
+    "# Set pad token if it does not exist\n",
+    "if tokenizer.pad_token is None:\n",
+    "    tokenizer.pad_token = tokenizer.eos_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Configure QLoRA\n",
+    "\n",
+    "We use QLoRA (Quantized Low-Rank Adaptation) to fine-tune the model efficiently. QLoRA freezes the full model weights and injects small, trainable \"adapter\" layers. This drastically reduces the number of trainable parameters, saving memory.\n",
+    "\n",
+    "We need to specify which layers of the model to apply LoRA to. For Gemma, these are the linear projection layers in the attention blocks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from peft import LoraConfig\n",
+    "\n",
+    "lora_config = LoraConfig(\n",
+    "    r=8,\n",
+    "    lora_alpha=16,\n",
+    "    target_modules=[\n",
+    "        \"q_proj\",\n",
+    "        \"k_proj\",\n",
+    "        \"v_proj\",\n",
+    "        \"o_proj\",\n",
+    "        \"gate_proj\",\n",
+    "        \"up_proj\",\n",
+    "        \"down_proj\",\n",
+    "    ],\n",
+    "    lora_dropout=0.05,\n",
+    "    bias=\"none\",\n",
+    "    task_type=\"CAUSAL_LM\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Define Training Arguments\n",
+    "\n",
+    "The `TrainingArguments` class holds all hyperparameters for the training run. `accelerate` handles device placement automatically, so we don't need to specify the device here. We use `fp16=True` for mixed-precision training, which is well-supported on Colab GPUs like the T4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import TrainingArguments\n",
+    "\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"gemma-2b-rutooro-finetuned-colab\", # Directory to save the model\n",
+    "    num_train_epochs=3,\n",
+    "    per_device_train_batch_size=2, # Start with a small batch size\n",
+    "    gradient_accumulation_steps=4, # Effective batch size will be 8\n",
+    "    learning_rate=2e-4,\n",
+    "    logging_steps=25,\n",
+    "    fp16=True, # Use fp16 for mixed-precision training on Colab\n",
+    "    push_to_hub=True, # Push the final adapter to the Hub\n",
+    "    report_to=\"tensorboard\", # Optional: for logging metrics\n",
+    "    lr_scheduler_type=\"cosine\",\n",
+    "    warmup_ratio=0.1,\n",
+    "    save_strategy=\"epoch\",\n",
+    "    evaluation_strategy=\"epoch\",\n",
+    "    load_best_model_at_end=True,\n",
+    "    metric_for_best_model=\"eval_loss\",\n",
+    "    greater_is_better=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Fine-tuning with SFTTrainer\n",
+    "\n",
+    "Now we bring everything together. The `SFTTrainer` from the `trl` library is a high-level wrapper that simplifies the training process. We pass it the model, tokenizer, datasets, LoRA configuration, and training arguments.\n",
+    "\n",
+    "Calling `trainer.train()` will start the fine-tuning process. The trainer will handle the training loop, gradient updates, evaluation, and saving checkpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trl import SFTTrainer\n",
+    "\n",
+    "trainer = SFTTrainer(\n",
+    "    model=model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    train_dataset=train_dataset,\n",
+    "    eval_dataset=test_dataset,\n",
+    "    peft_config=lora_config,\n",
+    "    dataset_text_field=\"text\",\n",
+    "    args=training_args,\n",
+    "    max_seq_length=1024, # Adjust based on your VRAM\n",
+    "    packing=True, # Pack multiple short examples into one sequence for efficiency\n",
+    ")\n",
+    "\n",
+    "# Start training\n",
+    "trainer.train()\n",
+    "\n",
+    "# Save the final adapter\n",
+    "trainer.save_model(f\"{training_args.output_dir}/final_adapter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Inference and Evaluation\n",
+    "\n",
+    "After fine-tuning, the model is ready to be used for inference. The `trainer` object automatically loads the best version of the adapter. We can use this model to generate responses to new instructions.\n",
+    "\n",
+    "We will format a sample instruction, tokenize it, and pass it to the model's `generate` function to get a response. Remember to move the tokenized input to the correct device (`cuda`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The trainer loads the best model state, so we can directly use it for inference.\n",
+    "model.eval() # Set the model to evaluation mode\n",
+    "\n",
+    "# Create a sample instruction\n",
+    "prompt_text = \"Translate this to Rutooro: I am going to the market.\"\n",
+    "\n",
+    "formatted_prompt = f\"\"\"### Instruction:\\n",
+    "{prompt_text}\\n",
+    "### Response:\"\"\"\n",
+    "\n",
+    "# Tokenize the input and move to the GPU\n",
+    "inputs = tokenizer(formatted_prompt, return_tensors=\"pt\").to(device)\n",
+    "\n",
+    "# Generate a response\n",
+    "with torch.no_grad():\n",
+    "    outputs = model.generate(**inputs, max_new_tokens=50, do_sample=True, top_k=50, top_p=0.95)\n",
+    "\n",
+    "# Decode and print the response\n",
+    "response_text = tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+    "print(response_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading the Adapter for a New Session\n",
+    "\n",
+    "If you were starting a new notebook session, you would load the quantized base model first (with `device_map='auto'`) and then apply the fine-tuned LoRA adapter on top of it. The code below shows how you would do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from peft import PeftModel\n",
+    "\n",
+    "# Path to your saved adapter\n",
+    "adapter_path = f\"{training_args.output_dir}/final_adapter\"\n",
+    "\n",
+    "# --- Code to load model from scratch (for a new session) ---\n",
+    "# 1. Load the quantized base model\n",
+    "base_model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_id,\n",
+    "    quantization_config=bnb_config,\n",
+    "    device_map=\"auto\"\n",
+    ")\n",
+    "\n",
+    "# 2. Load the PeftModel by merging the adapter into the base model\n",
+    "inference_model = PeftModel.from_pretrained(base_model, adapter_path)\n",
+    "\n",
+    "# You can now use `inference_model` for generation just like we did above\n",
+    "print(\"Inference model loaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 8: Save and Push the Final Model\n",
+    "\n",
+    "The training process automatically saved the adapter in the output directory (`gemma-2b-rutooro-finetuned`). Because we set `push_to_hub=True` in the `TrainingArguments`, the trainer also attempted to push the model to the Hugging Face Hub after training.\n",
+    "\n",
+    "You can also run the command manually to push the final adapter to the Hub. This will create a new repository under your user account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Push the final adapter to the Hugging Face Hub\n",
+    "trainer.push_to_hub()\n",
+    "\n",
+    "print(f\"Adapter pushed to Hugging Face Hub at: https://huggingface.co/{training_args.hub_model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "You have successfully fine-tuned the Gemma-2B model on a custom dataset using QLoRA on your Apple Silicon Mac. You can now share your model adapter, use it in other applications, or continue to refine it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This commit introduces a new version of the Gemma-2B fine-tuning notebook, specifically adapted for use in Google Colab with a standard GPU runtime.

The new notebook, `gemma-2b-finetune-colab.ipynb`, includes the following modifications:
- Device configuration updated from Apple MPS to NVIDIA CUDA.
- Model loading now uses `device_map='auto'`.
- Mixed-precision training is set to `fp16=True` for broader compatibility with Colab GPUs.
- Installation commands are optimized for the Colab environment.