### PR TITLE
feat: Add notebook for GGUF conversion

### DIFF
--- a/convert-to-gguf.ipynb
+++ b/convert-to-gguf.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Convert Fine-Tuned Gemma Model to GGUF\n",
+    "\n",
+    "This notebook takes a fine-tuned Gemma model (base + LoRA adapter), merges them, and converts the final model to the GGUF format for efficient CPU-based inference. It also saves the final GGUF file to Google Drive and uploads it to a Hugging Face repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Setup and Environment\n",
+    "\n",
+    "First, we mount Google Drive to access our saved model adapter. Then, we install the necessary libraries. `llama-cpp-python` is essential for the conversion process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q -U torch transformers bitsandbytes peft accelerate huggingface_hub\n",
+    "!pip install -q -U llama-cpp-python --no-cache-dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Load, Merge, and Save the Fine-Tuned Model\n",
+    "\n",
+    "Here, we load the original `gemma-2b-it` base model, then load the LoRA adapter we trained and saved to Google Drive. We merge the adapter weights into the base model to create our full fine-tuned model. Finally, we save this merged model to a local directory in this Colab session so the conversion script can access it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "from peft import PeftModel\n",
+    "import os\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "base_model_id = \"google/gemma-2b-it\"\n",
+    "# This must match the output_dir from the training notebook\n",
+    "adapter_folder_name = \"gemma-2b-it-rutooro-A100\"\n",
+    "adapter_path = f\"/content/drive/MyDrive/{adapter_folder_name}/final_adapter\"\n",
+    "\n",
+    "# Path for the temporarily saved merged model\n",
+    "merged_model_dir = \"/content/merged_model\"\n",
+    "\n",
+    "# --- Load Base Model ---\n",
+    "print(f\"Loading base model: {base_model_id}\")\n",
+    "base_model = AutoModelForCausalLM.from_pretrained(\n",
+    "    base_model_id,\n",
+    "    torch_dtype=torch.bfloat16, # Use the same dtype as training for consistency\n",
+    "    device_map=\"auto\"\n",
+    ")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(base_model_id)\n",
+    "\n",
+    "# --- Load and Merge LoRA Adapter ---\n",
+    "print(f\"Loading adapter from: {adapter_path}\")\n",
+    "# Load the PEFT model by combining the base model with the adapter\n",
+    "model = PeftModel.from_pretrained(base_model, adapter_path)\n",
+    "\n",
+    "# Merge the adapter weights into the base model\n",
+    "print(\"Merging adapter into the base model...\")\n",
+    "model = model.merge_and_unload()\n",
+    "print(\"Merge complete.\")\n",
+    "\n",
+    "# --- Save Merged Model ---\n",
+    "print(f\"Saving merged model to: {merged_model_dir}\")\n",
+    "os.makedirs(merged_model_dir, exist_ok=True)\n",
+    "model.save_pretrained(merged_model_dir)\n",
+    "tokenizer.save_pretrained(merged_model_dir)\n",
+    "print(\"Merged model saved successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Convert to GGUF\n",
+    "\n",
+    "Now we use the conversion script from the `llama.cpp` repository to transform our saved model into a GGUF file. We will use the `Q4_K_M` quantization type, which provides a good balance between model size and performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clone the llama.cpp repository\n",
+    "!git clone https://github.com/ggerganov/llama.cpp.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define paths\n",
+    "gguf_model_name = \"rutooro-gemma-2b-it.q4_k_m.gguf\"\n",
+    "gguf_output_path = f\"/content/{gguf_model_name}\"\n",
+    "conversion_script_path = \"/content/llama.cpp/convert.py\"\n",
+    "\n",
+    "# Run the conversion script\n",
+    "!python {conversion_script_path} {merged_model_dir} \\\n",
+    "  --outfile {gguf_output_path} \\\n",
+    "  --outtype q4_k_m\n",
+    "\n",
+    "print(f\"GGUF model created at: {gguf_output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Save GGUF to Google Drive\n",
+    "\n",
+    "Now that the GGUF file is created, we'll copy it to your Google Drive for safekeeping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define destination path in Google Drive\n",
+    "drive_gguf_path = f\"/content/drive/MyDrive/{adapter_folder_name}/{gguf_model_name}\"\n",
+    "\n",
+    "# Copy the file\n",
+    "!cp {gguf_output_path} {drive_gguf_path}\n",
+    "\n",
+    "print(f\"GGUF file saved to your Google Drive at: {drive_gguf_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Upload GGUF to Hugging Face Hub\n",
+    "\n",
+    "Finally, we'll upload the GGUF model to your Hugging Face repository. This makes it easily accessible for others to download and use with tools like `llama.cpp`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import HfApi, login\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "hf_repo_id = \"cle-13/gemma-2b-it-rutooro-A100\"\n",
+    "\n",
+    "# --- Login to Hugging Face ---\n",
+    "# You will need a Hugging Face token with 'write' permissions\n",
+    "print(\"Please log in to Hugging Face...\")\n",
+    "login()\n",
+    "\n",
+    "# --- Upload the File ---\n",
+    "print(f\"Uploading {gguf_model_name} to {hf_repo_id}...\")\n",
+    "api = HfApi()\n",
+    "api.upload_file(\n",
+    "    path_or_fileobj=gguf_output_path,\n",
+    "    path_in_repo=gguf_model_name,\n",
+    "    repo_id=hf_repo_id,\n",
+    "    repo_type=\"model\"\n",
+    ")\n",
+    "\n",
+    "print(\"Upload complete!\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This commit introduces a new Jupyter notebook, `convert-to-gguf.ipynb`. This notebook provides a complete workflow to convert a fine-tuned LoRA model into the GGUF format for CPU-based inference.

The notebook includes the following steps:
1.  Mounts Google Drive to access the saved model adapter.
2.  Installs all necessary dependencies, including `llama-cpp-python`.
3.  Loads the base model and the fine-tuned adapter.
4.  Merges the adapter into the base model.
5.  Saves the merged model to a temporary directory.
6.  Clones the `llama.cpp` repository and uses its script to convert the merged model to a Q4_K_M GGUF file.
7.  Saves the final GGUF file back to Google Drive.
8.  Uploads the GGUF file to a specified Hugging Face Hub repository.